### PR TITLE
Towards honoring action(m, x)

### DIFF
--- a/src/requirements_info.jl
+++ b/src/requirements_info.jl
@@ -23,6 +23,7 @@ function POMDPs.requirements_info(policy::POMCPPlanner, b)
     rng = MersenneTwister(1)
     if @implemented(rand(::typeof(rng), ::typeof(b))) &&
         @implemented(actions(::typeof(problem)))
+        # TODO require actions(::POMDP , :::POMCPObsNode)
         s = rand(rng, b)
         a = first(actions(problem))
         if @implemented generate_sor(::typeof(policy.problem), ::typeof(s), ::typeof(a), ::typeof(rng))

--- a/src/requirements_info.jl
+++ b/src/requirements_info.jl
@@ -17,15 +17,14 @@ function POMDPs.requirements_info(solver::AbstractPOMCPSolver, problem::POMDP, b
 end
 
 function POMDPs.requirements_info(policy::POMCPPlanner, b)
-    @show_requirements action(policy, b)    
+    @show_requirements action(policy, b)
 
     problem = policy.problem
     rng = MersenneTwister(1)
     if @implemented(rand(::typeof(rng), ::typeof(b))) &&
-        @implemented(actions(::typeof(problem)))
-        # TODO require actions(::POMDP , :::POMCPObsNode)
+        @implemented(actions(::typeof(problem), ::typeof(b)))
         s = rand(rng, b)
-        a = first(actions(problem))
+        a = first(actions(problem, b))
         if @implemented generate_sor(::typeof(policy.problem), ::typeof(s), ::typeof(a), ::typeof(rng))
             sp, o, r = generate_sor(policy.problem, s, a, rng)
 
@@ -74,8 +73,8 @@ end
     @req hash(::O)
     # from insert_obs_node!
     @req n_actions(::P)
-    @req actions(::P)
-    AS = typeof(actions(p.problem))
+    @req actions(::P, ::typeof(hnode))
+    AS = typeof(actions(p.problem, hnode))
     @subreq estimate_value(p.solved_estimator, p.problem, s, hnode, steps)
     @req discount(::P)
 end

--- a/src/solver.jl
+++ b/src/solver.jl
@@ -2,7 +2,7 @@ function action_info(p::POMCPPlanner, b; tree_in_info=false)
     local a::actiontype(p.problem)
     info = Dict{Symbol, Any}()
     try
-        tree = POMCPTree(p.problem, p.solver.tree_queries)
+        tree = POMCPTree(p.problem, b, p.solver.tree_queries)
         a = search(p, b, tree, info)
         p._tree = tree
         if p.solver.tree_in_info || tree_in_info

--- a/src/visualization.jl
+++ b/src/visualization.jl
@@ -1,12 +1,12 @@
 function D3Trees.D3Tree(p::POMCPPlanner; title="POMCP Tree", kwargs...)
     @warn("""
          D3Tree(planner::POMCPPlanner) is deprecated and may be removed in the future. Instead, please use
-             
+
              a, info = action_info(planner, b)
              D3Tree(info[:tree])
 
          Or, you can get this info from a POMDPSimulators History
-         
+
              info = first(ainfo_hist(hist))
              D3Tree(info[:tree])
          """)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,7 +15,7 @@ pomdp = BabyPOMDP()
 solver = POMCPSolver(rng = MersenneTwister(1))
 planner = solve(solver, pomdp)
 
-tree = BasicPOMCP.POMCPTree(pomdp, solver.tree_queries)
+tree = BasicPOMCP.POMCPTree(pomdp, initialstate_distribution(pomdp), solver.tree_queries)
 node = BasicPOMCP.POMCPObsNode(tree, 1)
 
 r = @inferred BasicPOMCP.simulate(planner, initialstate(pomdp, MersenneTwister(1)), node, 20)
@@ -30,7 +30,7 @@ a, info = action_info(planner, initialstate_distribution(pomdp))
 println("time below should be about 0.1 seconds")
 etime = @elapsed a, info = action_info(planner, initialstate_distribution(pomdp))
 @show etime
-@test etime < 0.2 
+@test etime < 0.2
 @show info[:search_time_us]
 
 solver = POMCPSolver(max_time=0.1, tree_queries=typemax(Int), rng = MersenneTwister(1))


### PR DESCRIPTION
In an effort to take a step towards fixing JuliaPOMDP/POMDPs.jl#226 I made `BasicPOMCP` use `POMDPs.actions(pomdp, b)`.`BasicPOMCP` will now call this function with `b` being either the root belief or a `POMCPObsNode` in  similar fashion as [`POMCPOW` does already](https://github.com/JuliaPOMDP/POMCPOW.jl/blob/master/src/solver2.jl#L29).

In order to provide a shared interface for both `POMCPObsNode` and `POWTreeObsNode` I moved
- `current_obs(h)` 
- `isroot(h)`

to `BasicPOMCP`. I will file a pull request for `POMCPOW` to use these functions.

This is probably only an intermediate solution to this problem. @zsunberg suggested that maybe later `POMDPs.jl` should specify the existence of `history(b)` to access the history for belief types that have a notion of this history.

**Edit:** Maybe `current_obs` and `isroot` are rather something that should be moved to `MCTS`? I just noticed that [`MCTS` also provides `isroot`](https://github.com/JuliaPOMDP/MCTS.jl/blob/38cc87950b36ceafc3b4282dec1686542fee4dc0/src/dpw_types.jl#L229).