### PR TITLE
Relax Colors version to 0.9-0.12

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -22,7 +22,7 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 [compat]
 BeliefUpdaters = "0.2"
 CPUTime = "1"
-Colors = "0.12"
+Colors = "0.9, 0.10, 0.11, 0.12"
 D3Trees = "0.3"
 MCTS = "0.4"
 POMDPLinter = "0.1"


### PR DESCRIPTION
Just like MCTS.jl (https://github.com/JuliaPOMDP/MCTS.jl/pull/72), strict version requirements on Colors.jl were causing unnecessary dependency errors with other packages.