### PR TITLE
FOValue using underlying mdp

### DIFF
--- a/src/BasicPOMCP.jl
+++ b/src/BasicPOMCP.jl
@@ -22,7 +22,7 @@ using Printf
 using POMDPLinter: @POMDP_require, @show_requirements
 
 import POMDPs: action, solve, updater
-import POMDPModelTools: action_info
+import POMDPModelTools: action_info, UnderlyingMDP
 import POMDPLinter
 
 using MCTS

--- a/src/rollout.jl
+++ b/src/rollout.jl
@@ -65,8 +65,8 @@ function convert_estimator(est::FORollout, solver, pomdp)
     SolvedFORollout(policy, solver.rng)
 end
 
-function convert_estimator(est::FOValue, solver::AbstractPOMCPSolver, pomdp::POMDPs.POMDP)
-    policy = MCTS.convert_to_policy(est.solver, pomdp)
+function convert_estimator(est::FOValue, solver, pomdp::POMDPs.POMDP)
+    policy = MCTS.convert_to_policy(est.solver, UnderlyingMDP(pomdp))
     SolvedFOValue(policy)
 end
 


### PR DESCRIPTION
`solve(::ValueIterationSolver, ::POMDP)` is no longer supported.

Extract underlying MDP for VI compatibility.